### PR TITLE
Fix set LD_LIBRARY_PATH. Should be setenv

### DIFF
--- a/setupCODA3.tcsh
+++ b/setupCODA3.tcsh
@@ -4,7 +4,7 @@
 
 set PATH=`echo $PATH | awk -v RS=: -v ORS=: '/coda/ {next} {print}' | sed 's/:*$//'`
 if ($?LD_LIBRARY_PATH == "1") then
-   set LD_LIBRARY_PATH=`echo $LD_LIBRARY_PATH | awk -v RS=: -v ORS=: '/coda/ {next} {print}' | sed 's/:*$//'`
+   setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | awk -v RS=: -v ORS=: '/coda/ {next} {print}' | sed 's/:*$//'`
 endif
 
 ########################################


### PR DESCRIPTION
This should be setenv, as otherwise it breaks the environment when
logging through MATE desktop.